### PR TITLE
Fixed swagger documentation for GetChapter endpoint

### DIFF
--- a/src/KamiYomu.Web/Areas/Public/Controllers/CollectionController.cs
+++ b/src/KamiYomu.Web/Areas/Public/Controllers/CollectionController.cs
@@ -171,10 +171,9 @@ public class CollectionController : ControllerBase
     [ProducesResponseType(typeof(PublicApiErrorResponse), StatusCodes.Status500InternalServerError)]
     [ProducesResponseType(typeof(PublicApiErrorResponse), StatusCodes.Status403Forbidden)]
     [SwaggerOperation(
-    Summary = "List chapters for a collection item",
-    Description = "Returns a paginated list of chapter download records associated with the specified "
-                + "library. Includes chapter metadata, download status, timestamps, and related "
-                + "information. Returns 404 if the library does not exist."
+        Summary = "Get a single chapter",
+        Description = "Returns information for a single chapter download record identified by chapterDownloadId " +
+                      "within the specified library. Returns 404 if the library or chapter does not exist."
     )]
     public IActionResult GetChapter(
         [FromRoute] Guid libraryId,


### PR DESCRIPTION
The Swagger documentation for the GetChapter endpoint incorrectly described the operation as returning a paginated list of chapters. However, the endpoint actually retrieves a single chapter download record based on the provided libraryId and chapterDownloadId.

This PR updates the SwaggerOperation summary and description to accurately reflect the endpoint’s behavior, ensuring the generated API documentation matches the actual implementation.

Fixes #229.